### PR TITLE
Fixed multiline descriptions breaking tabulated view

### DIFF
--- a/gitlab-mode.el
+++ b/gitlab-mode.el
@@ -70,9 +70,8 @@
                             (assoc-default 'name p)
                             (assoc-default 'name owner)
                             (assoc-default 'name namespace)
-                            (assoc-default 'description p)))))
+                            (replace-regexp-in-string "\^M\\|\n" " " (assoc-default 'description p))))))
           projects))
-
 
 ;; Issues
 


### PR DESCRIPTION
If your Gitlab project has multi line description then it breaks tabulated view generated by 'gitlab-show-projects'.

This PR fixes this behavior.