### PR TITLE
Initial support for pagination refs #5

### DIFF
--- a/gitlab-issues.el
+++ b/gitlab-issues.el
@@ -30,17 +30,32 @@
 (require 'gitlab-utils)
 
 
-(defun gitlab-list-issues ()
+(defun gitlab-list-issues (page per-page)
   "Get all issues created by authenticated user.
 STATE Return all issues or just those that are opened or closed
 LABELS - Comma-separated list of label names"
   (let ((params '()))
-    ;; (when state
-    ;;   (add-to-list params (cons "state" state)))
-    ;; (when labels
-    ;;   (add-to-list params (cons "labels" labels)))
-    (perform-gitlab-request "GET" "issues" params 200)))
+    (add-to-list 'params (cons 'per_page (number-to-string per-page)))
+    (add-to-list 'params (cons 'page (number-to-string page)))
+    (perform-gitlab-request "GET"
+                            "issues"
+                            params
+                            200)))
 
+(defun gitlab-list-all-issues ()
+  "Get a list of all issues."
+  (interactive)
+  (let* ((page 1)
+         (per-page 100)
+         (issues)
+         (all-issues (gitlab-list-issues page per-page))
+         (all-issues-count (length all-issues)))
+    (while (>= all-issues-count (* page per-page))
+      (setq issues (gitlab-list-issues page per-page))
+      (setq all-issues (vconcat all-issues issues))
+      (setq all-issues-count (length all-issues))
+      (setq page (1+ page)))
+    all-issues))
 
 (defun gitlab--get-issue-uri (project-id issue-id)
   (s-concat "projects/"
@@ -49,17 +64,38 @@ LABELS - Comma-separated list of label names"
             "/issues/"
             (number-to-string issue-id)))
 
-(defun gitlab-list-project-issues (project-id)
+(defun gitlab-list-project-issues (project-id &optional page per-page)
   "Get a list of project issues.
 
 PROJECT-ID : The ID of a project"
-  (perform-gitlab-request "GET"
-                          (s-concat "projects/"
-                                    (url-hexify-string
-                                     (format "%s" project-id))
-                                    "/issues")
-                          nil
-                          200))
+  (let ((params '()))
+    (add-to-list 'params (cons 'per_page (number-to-string per-page)))
+    (add-to-list 'params (cons 'page (number-to-string page)))
+    (perform-gitlab-request "GET"
+                            (s-concat "projects/"
+                                      (url-hexify-string
+                                       (format "%s" project-id))
+                                      "/issues")
+                            params
+                            200)))
+
+(defun gitlab-list-all-project-issues (project-id &optional page per-page)
+  "Get a list of all PROJECT-ID issues."
+  (interactive)
+  (let* ((page 1)
+         (per-page 100)
+         (issues)
+         (all-issues (gitlab-list-project-issues project-id page per-page))
+         (all-issues-count (length all-issues)))
+    (while (>= all-issues-count (* page per-page))
+      (setq issues (gitlab-list-project-issues project-id page per-page))
+      (setq all-issues (vconcat all-issues issues))
+      (setq all-issues-count (length all-issues))
+      (setq page (1+ page)))
+    all-issues))
+
+
+
 
 (defun gitlab-get-issue (project-id issue-id)
   "Gets a single project issue.

--- a/gitlab-mode.el
+++ b/gitlab-mode.el
@@ -56,21 +56,27 @@
   (pop-to-buffer "*Gitlab projects*" nil)
   (gitlab-projects-mode)
   (setq tabulated-list-entries
-        (create-projects-entries (gitlab-list-projects)))
+        (create-projects-entries (gitlab-list-all-projects)))
   (tabulated-list-print t))
 
 (defun create-projects-entries (projects)
   "Create entries for 'tabulated-list-entries from PROJECTS."
   (mapcar (lambda (p)
-            (let ((id (number-to-string (assoc-default 'id p)))
-                  (owner (assoc-default 'owner p))
-                  (namespace (assoc-default 'namespace p)))
-              (list id
+            (let* ((id (assoc-default 'id p))
+                   (project-name (assoc-default 'name p))
+                   (owner (assoc-default 'owner p))
+                   (owner-name (assoc-default 'name owner))
+                   (namespace (assoc-default 'namespace p))
+                   (namespace-name (assoc-default 'name namespace))
+                   (description (assoc-default 'description p)))
+              (list (number-to-string id)
                     (vector ;id
-                            (assoc-default 'name p)
-                            (assoc-default 'name owner)
-                            (assoc-default 'name namespace)
-                            (assoc-default 'description p)))))
+                     project-name
+                     owner-name
+                     namespace-name
+                     (if  description
+                         description
+                       "Description")))))
           projects))
 
 
@@ -98,7 +104,7 @@
   (pop-to-buffer "*Gitlab issues*" nil)
   (gitlab-issues-mode)
   (setq tabulated-list-entries
-        (create-issues-entries (gitlab-list-issues)))
+        (create-issues-entries (gitlab-list-all-issues)))
   (tabulated-list-print t))
 
 

--- a/gitlab-notes.el
+++ b/gitlab-notes.el
@@ -37,21 +37,43 @@
             (number-to-string issue-id)
             "/notes"))
 
-(defun gitlab-list-project-issue-notes (project-id issue-id)
+(defun gitlab-list-project-issue-notes (project-id issue-id &optional page per-page)
   "Get a list of project issue notes.
 
 PROJECT-ID : The ID of a project
+ISSUE-ID : The ID of a project issue
+PAGE: current page number
+PER-PAGE: number of items on page max 100"
+  (let* ((params '()))
+    (add-to-list 'params (cons 'per_page (number-to-string per-page)))
+    (add-to-list 'params (cons 'page (number-to-string page)))
+    (perform-gitlab-request "GET"
+                            (gitlab--get-notes-uri
+                             project-id
+                             issue-id)
+                            params
+                            200)))
+
+(defun gitlab-list-all-project-issue-notes (project-id issue-id)
+  "Get a list of allproject issue notes.
+
+PROJECT-ID : The ID of a project
 ISSUE-ID : The ID of a project issue"
-  (perform-gitlab-request "GET"
-                          (gitlab--get-notes-uri
-                           project-id
-                           issue-id)
-                          nil
-                          200))
+  (interactive)
+  (let* ((page 1)
+         (per-page 100)
+         (notes)
+         (all-notes (gitlab-list-project-issue-notes project-id issue-id page per-page))
+         (all-notes-count (length all-notes)))
+    (while (>= all-notes-count (* page per-page))
+      (setq notes (gitlab-list-project-issue-notes project-id issue-id page per-page))
+      (setq all-notes (vconcat all-notes notes))
+      (setq all-notes-count (length all-notes))
+      (setq page (1+ page)))
+    all-notes))
 
 (defun gitlab-get-issue-note (project-id issue-id note-id)
-  "Doc PROJECT-ID ISSUE-ID NOTE-ID."
-  )
+  "Doc PROJECT-ID ISSUE-ID NOTE-ID.")
 
 (defun gitlab-add-issue-note (project-id issue-id body)
   "Add note for project issue.

--- a/gitlab-projects.el
+++ b/gitlab-projects.el
@@ -30,9 +30,32 @@
 (require 'gitlab-utils)
 
 
-(defun gitlab-list-projects ()
-  "Get a list of projects accessible by the authenticated user."
-  (perform-gitlab-request "GET" "projects" nil 200))
+(defun gitlab-list-projects (&optional page per-page)
+  "Get a list of projects accessible by the authenticated user.
+PAGE: current page number
+PER-PAGE: number of items on page max 100"
+  (let* ((params '()))
+    (add-to-list 'params (cons 'per_page (number-to-string per-page)))
+    (add-to-list 'params (cons 'page (number-to-string page)))
+    (perform-gitlab-request "GET"
+                            "projects"
+                            params
+                            200)))
+
+(defun gitlab-list-all-projects ()
+  "Get a list of all projects accessible by the authenticated user."
+  (interactive)
+    (let* ((page 1)
+           (per-page 100)
+           (projects)
+           (all-projects (gitlab-list-projects page per-page))
+           (all-projects-count (length all-projects)))
+      (while (>= all-projects-count (* page per-page))
+        (setq projects (gitlab-list-projects page per-page))
+        (setq all-projects (vconcat all-projects projects))
+        (setq all-projects-count (length all-projects))
+        (setq page (1+ page)))
+      all-projects))
 
 
 (defun gitlab-list-owned-projects ()

--- a/gitlab-utils.el
+++ b/gitlab-utils.el
@@ -78,15 +78,18 @@ Defaults to `error'."
 
 
 (defun gitlab--perform-get-request (uri params)
+  "Doc string URI PARAMS."
   (let* ((response (request (gitlab--get-rest-uri uri)
                             :type "GET"
                             :headers (gitlab--get-headers)
                             :sync t
                             :params params
+                            ;;:data params
                             :parser 'json-read)))
     response))
 
 (defun gitlab--perform-post-request (uri params)
+  "Doc string URI PARAMS."
   (let ((response (request (gitlab--get-rest-uri uri)
                            :type "POST"
                            :headers (gitlab--get-headers)
@@ -96,6 +99,7 @@ Defaults to `error'."
     response))
 
 (defun gitlab--perform-put-request (uri params)
+  "Doc string URI PARAMS."
   (let ((response (request (gitlab--get-rest-uri uri)
                            :type "PUT"
                            :headers (gitlab--get-headers)
@@ -106,6 +110,7 @@ Defaults to `error'."
 
 
 (defun perform-gitlab-request (type uri params status-code)
+  "Doc string TYPE URI PARAMS STATUS-CODE."
   (let ((response
          (cond ((string= type "POST")
 		(gitlab--perform-post-request uri params))


### PR DESCRIPTION
By default Gitlab API fetches 20 projects/milestones/issues/notes only.

With this patch `gitlab-show-projects` and `gitlab-show-issues` can display all available projects and issues. 
It also provides support for project issue notes. 

This is synchronous, so it can lock Emacs. Personally I don't see any problem with performance. 
However my gitlab is not full of data and I don't have huge amount of projects/issues etc.

I'm going to convert this code to async when I find some free time.