### PR TITLE
README: working example config for gitlab.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can install emacs-gitlab manually by placing it on your `load-path` and
 
 * Setup your Gitlab configurations :
 
-        $ (setq gitlab-host "http://mygitlab.com"
+        $ (setq gitlab-host "https://gitlab.com"
                 gitlab-username "foo"
                 gitlab-password "bar")
 

--- a/gitlab-issues.el
+++ b/gitlab-issues.el
@@ -67,12 +67,13 @@ ISSUE-ID : The ID of a project issue"
             "/issues/"
             issue-id))
 
-(defun gitlab-list-project-issues (project-id &optional page per-page)
+(defun gitlab-list-project-issues (project-id &optional page per-page params)
   "Get a list of project issues.
 PROJECT-ID : The ID of a project
 PAGE: current page number
-PER-PAGE: number of items on page max 100"
-  (let ((params '()))
+PER-PAGE: number of items on page max 100
+PARAMS: an alist for query parameters. Exple: '((state . \"opened\"))"
+  (let ((params params))
     (when page
       (add-to-list 'params (cons 'per_page (number-to-string per-page))))
     (when per-page


### PR DESCRIPTION
I suggest to make the example config work for some people, so for gitlab.com. In that case, it needs https. It could be tricky to catch…