### PR TITLE
Give query paramaters as params to list-project-issues function

### DIFF
--- a/gitlab-issues.el
+++ b/gitlab-issues.el
@@ -67,12 +67,13 @@ ISSUE-ID : The ID of a project issue"
             "/issues/"
             issue-id))
 
-(defun gitlab-list-project-issues (project-id &optional page per-page)
+(defun gitlab-list-project-issues (project-id &optional page per-page params)
   "Get a list of project issues.
 PROJECT-ID : The ID of a project
 PAGE: current page number
-PER-PAGE: number of items on page max 100"
-  (let ((params '()))
+PER-PAGE: number of items on page max 100
+PARAMS: an alist for query parameters. Exple: '((state . \"opened\"))"
+  (let ((params params))
     (when page
       (add-to-list 'params (cons 'per_page (number-to-string per-page))))
     (when per-page


### PR DESCRIPTION
so than we can add ?state=opened to the api endpoint, and get the list
of opened issues in a project.

I'd prefer to have "params" befor "page" and "per-page", but other
functions don't have that (yet?).

Looks like many other functions would benefit from an addition like this, isn't it ? 