### PR TITLE
fix typo

### DIFF
--- a/gitlab-mode.el
+++ b/gitlab-mode.el
@@ -132,7 +132,7 @@
 
 
 (defun gitlab-describe-project (&optional button)
-  "Describe the current pproject.
+  "Describe the current project.
 If optional arg BUTTON is non-nil, describe its associated project."
   (interactive)
   (let ((project (gitlab-get-project (tabulated-list-get-id))))


### PR DESCRIPTION
Hello, I fixed a typo in a docstring.

AFAICT this has not been fixed in nlamirault/emacs-gitlab develop branch.

I hope that I followed the contribution guidelines to your satisfaction.

Thanks for making this useful package.