### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -106,6 +106,4 @@
          ;; (error
          ;;  (message (ansi-red "[Scame] Error during unit tests : %s" ex))))))
 
-
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
**Note that some of the tests fail, but it is the same tests that
also fail without these changes.**

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.